### PR TITLE
Rm deprecated nowarn_bif_clash compile flag

### DIFF
--- a/Emakefile
+++ b/Emakefile
@@ -1,6 +1,5 @@
 {"src/*", [debug_info,
            {outdir, "ebin"},
            {i, "include"},
-           nowarn_bif_clash,
            warn_export_all,
            warn_unused_import]}.


### PR DESCRIPTION
From [compile module documentation](http://www.erlang.org/doc/man/compile.html):

> This option is removed, it will generate a fatal error if used.
