### PR TITLE
Rebarify

### DIFF
--- a/src/conc.app.src
+++ b/src/conc.app.src
@@ -1,0 +1,3 @@
+{application, conc,
+ [{description, "Concurrent Lists in Erlang"},
+  {applications, [kernel, stdlib]}]}.


### PR DESCRIPTION
Enable erl-conc to be built through [rebar](https://github.com/basho/rebar) and thus be dependable upon in other rebar-enabled applications.
